### PR TITLE
通知条件・対象担当者の見直し（該当なしスキップ / 明日除外 / 丸アイコン / 複数担当者）

### DIFF
--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -34,6 +34,7 @@ jobs:
           BACKLOG_SPACE: ${{ secrets.BACKLOG_SPACE }}
           BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }} # 例: backlog.jp / backlog.com
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
+          BACKLOG_ASSIGNEE_EMAILS: ${{ secrets.BACKLOG_ASSIGNEE_EMAILS }} # 通知対象のメールアドレス（カンマ区切り）
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TIMEZONE: Asia/Tokyo
           SKIP_HOLIDAYS: "true"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Logs
+*.log
+
+# OS files
+.DS_Store

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,9 +212,9 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
     section('🟨 明日', groups.tomorrow)
   ].join('\n\n');
 
-  // 何もなければ送らない運用にしたい場合は以下でreturn
-  // const total = groups.overdue.length + groups.today.length + groups.tomorrow.length;
-  // if (total === 0) { console.log('該当なしのため送信しません'); return; }
+  // 該当課題がない場合は送信しない
+  const total = groups.overdue.length + groups.today.length + groups.tomorrow.length;
+  if (total === 0) { console.log('該当なしのため送信しません'); return; }
 
   // Slack送信
   const slackPayload: SlackMessage = { text };

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,17 +112,20 @@ const getUsers = async (): Promise<BacklogUser[]> => {
   return fetchJson(url);
 };
 
-// メールアドレス（カンマ区切り）→ 担当者IDの配列に解決する
+// APIキー本人は常に対象に含めつつ、メールアドレス（カンマ区切り）で指定された担当者を追加する
 const resolveAssigneeIds = async (emailsCsv: string): Promise<number[]> => {
+  // 本人は常に通知対象
+  const myself = await getMyself();
+  const ids = new Set<number>([myself.id]);
+
   const emails = emailsCsv
     .split(',')
     .map(e => e.trim().toLowerCase())
     .filter(Boolean);
 
-  // 未設定ならAPIキー本人を対象にする（後方互換）
+  // 追加指定がなければ本人のみ
   if (emails.length === 0) {
-    const myself = await getMyself();
-    return [myself.id];
+    return [...ids];
   }
 
   const users = await getUsers();
@@ -132,19 +135,18 @@ const resolveAssigneeIds = async (emailsCsv: string): Promise<number[]> => {
       .map(u => [u.mailAddress.toLowerCase(), u.id] as const)
   );
 
-  const resolved: number[] = [];
   const notFound: string[] = [];
   for (const email of emails) {
     const id = idByEmail.get(email);
     if (id === undefined) notFound.push(email);
-    else resolved.push(id);
+    else ids.add(id);
   }
 
   if (notFound.length > 0) {
     throw new Error(`次のメールアドレスに一致するBacklogユーザーが見つかりません: ${notFound.join(', ')}`);
   }
 
-  return [...new Set(resolved)]; // 重複除去
+  return [...ids]; // 本人＋指定担当者（重複除去済み）
 };
 
 const getProjectStatuses = async (projectId: number): Promise<BacklogStatus[]> => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,6 @@ interface BacklogUser {
 interface IssueGroups {
   overdue: BacklogIssue[];
   today: BacklogIssue[];
-  tomorrow: BacklogIssue[];
 }
 
 interface SlackMessage {
@@ -77,7 +76,6 @@ const SKIP_HOLIDAYS: boolean = (process.env.SKIP_HOLIDAYS || 'true') === 'true';
 
 // ==== 日付ユーティリティ（JST基準）====
 const today = DateTime.now().setZone(TIMEZONE).startOf('day');
-const tomorrow = today.plus({ days: 1 });
 const iso = (d: DateTime): string => d.toISODate() || ''; // YYYY-MM-DD
 
 // ==== 祝日スキップ ====
@@ -147,7 +145,7 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
 };
 
 // ==== メインロジック ====
-// 要件: 全ての課題 / 期限が「残り3日」「残り2日」「当日」「期限切れ」
+// 要件: 自分担当の課題 / 期限が「当日」「期限切れ」
 (async () => {
   if (!SPACE || !API_KEY || !SLACK_WEBHOOK_URL) {
     throw new Error('環境変数 BACKLOG_SPACE / BACKLOG_API_KEY / SLACK_WEBHOOK_URL が未設定です。');
@@ -155,7 +153,7 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
 
   // 期限の範囲：過去(期限切れ含む)〜明日までを一気に取得してグルーピング
   const since = today.minus({ days: 365 }); // 1年分拾えば十分。必要に応じて短縮可
-  const until = tomorrow;
+  const until = today; // 当日まで（明日以降は対象外）
 
   // 自分に担当された課題のみ取得
   const myself = await getMyself();
@@ -182,8 +180,7 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
   // グルーピング
   const groups: IssueGroups = {
     overdue: [], // 期限切れ（todayより過去）
-    today: [],   // 当日
-    tomorrow: [] // 明日
+    today: []    // 当日
   };
 
   for (const i of issues) {
@@ -193,7 +190,6 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
 
     if (diffDays < 0) groups.overdue.push(i);
     else if (diffDays === 0) groups.today.push(i);
-    else if (diffDays === 1) groups.tomorrow.push(i);
   }
 
     // Slack メッセージ整形
@@ -208,12 +204,11 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
   const text: string = [
     `:spiral_calendar_pad: Backlog 期限リマインド (${iso(today)})`,
     section('🟥 期限切れ', groups.overdue),
-    section('🟧 当日', groups.today),
-    section('🟨 明日', groups.tomorrow)
+    section('🟧 当日', groups.today)
   ].join('\n\n');
 
   // 該当課題がない場合は送信しない
-  const total = groups.overdue.length + groups.today.length + groups.tomorrow.length;
+  const total = groups.overdue.length + groups.today.length;
   if (total === 0) { console.log('該当なしのため送信しません'); return; }
 
   // Slack送信

--- a/src/index.ts
+++ b/src/index.ts
@@ -203,8 +203,8 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
 
   const text: string = [
     `:spiral_calendar_pad: Backlog 期限リマインド (${iso(today)})`,
-    section('🟥 期限切れ', groups.overdue),
-    section('🟧 当日', groups.today)
+    section('🔴 期限切れ', groups.overdue),
+    section('🟠 当日', groups.today)
   ].join('\n\n');
 
   // 該当課題がない場合は送信しない

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,8 @@ const API_KEY: string | undefined = process.env.BACKLOG_API_KEY;      // Backlog
 const SLACK_WEBHOOK_URL: string | undefined = process.env.SLACK_WEBHOOK_URL;
 const TIMEZONE: string = process.env.TIMEZONE || 'Asia/Tokyo';
 const SKIP_HOLIDAYS: boolean = (process.env.SKIP_HOLIDAYS || 'true') === 'true';
+// 通知対象の担当者メールアドレス（カンマ区切りで複数可）。未設定ならAPIキー本人が対象。
+const ASSIGNEE_EMAILS: string = process.env.BACKLOG_ASSIGNEE_EMAILS || '';
 
 // ==== 日付ユーティリティ（JST基準）====
 const today = DateTime.now().setZone(TIMEZONE).startOf('day');
@@ -105,6 +107,46 @@ const getMyself = async (): Promise<BacklogUser> => {
   return fetchJson(url);
 };
 
+const getUsers = async (): Promise<BacklogUser[]> => {
+  const url = `${API_BASE}/users?apiKey=${API_KEY}`;
+  return fetchJson(url);
+};
+
+// メールアドレス（カンマ区切り）→ 担当者IDの配列に解決する
+const resolveAssigneeIds = async (emailsCsv: string): Promise<number[]> => {
+  const emails = emailsCsv
+    .split(',')
+    .map(e => e.trim().toLowerCase())
+    .filter(Boolean);
+
+  // 未設定ならAPIキー本人を対象にする（後方互換）
+  if (emails.length === 0) {
+    const myself = await getMyself();
+    return [myself.id];
+  }
+
+  const users = await getUsers();
+  const idByEmail = new Map(
+    users
+      .filter(u => u.mailAddress)
+      .map(u => [u.mailAddress.toLowerCase(), u.id] as const)
+  );
+
+  const resolved: number[] = [];
+  const notFound: string[] = [];
+  for (const email of emails) {
+    const id = idByEmail.get(email);
+    if (id === undefined) notFound.push(email);
+    else resolved.push(id);
+  }
+
+  if (notFound.length > 0) {
+    throw new Error(`次のメールアドレスに一致するBacklogユーザーが見つかりません: ${notFound.join(', ')}`);
+  }
+
+  return [...new Set(resolved)]; // 重複除去
+};
+
 const getProjectStatuses = async (projectId: number): Promise<BacklogStatus[]> => {
   const url = `${API_BASE}/projects/${projectId}/statuses?apiKey=${API_KEY}`;
   return fetchJson(url);
@@ -125,9 +167,16 @@ const getCompletedStatusIds = async (projectIds: number[]): Promise<number[]> =>
   return completedIds;
 };
 
-const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIssue[]> => {
-  // params: object -> querystring
-  const q = new URLSearchParams(params);
+const fetchAllIssues = async (params: Record<string, string | string[]>): Promise<BacklogIssue[]> => {
+  // params: object -> querystring（配列値は同一キーで複数展開）
+  const q = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (Array.isArray(value)) {
+      for (const v of value) q.append(key, v);
+    } else {
+      q.append(key, value);
+    }
+  }
   // ページング
   const count = 100;
   let offset = 0;
@@ -145,7 +194,7 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
 };
 
 // ==== メインロジック ====
-// 要件: 自分担当の課題 / 期限が「当日」「期限切れ」
+// 要件: 指定担当者の課題 / 期限が「当日」「期限切れ」
 (async () => {
   if (!SPACE || !API_KEY || !SLACK_WEBHOOK_URL) {
     throw new Error('環境変数 BACKLOG_SPACE / BACKLOG_API_KEY / SLACK_WEBHOOK_URL が未設定です。');
@@ -155,11 +204,11 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
   const since = today.minus({ days: 365 }); // 1年分拾えば十分。必要に応じて短縮可
   const until = today; // 当日まで（明日以降は対象外）
 
-  // 自分に担当された課題のみ取得
-  const myself = await getMyself();
+  // 指定担当者（メールアドレスで解決）の課題のみ取得
+  const assigneeIds = await resolveAssigneeIds(ASSIGNEE_EMAILS);
   const allIssues = await fetchAllIssues({
     apiKey: API_KEY,
-    'assigneeId[]': String(myself.id),
+    'assigneeId[]': assigneeIds.map(String),
     dueDateSince: iso(since),
     dueDateUntil: iso(until),
     sort: 'dueDate',
@@ -193,8 +242,10 @@ const fetchAllIssues = async (params: Record<string, string>): Promise<BacklogIs
   }
 
     // Slack メッセージ整形
-  const issueLine = (it: BacklogIssue): string =>
-    `• <https://${SPACE}.${DOMAIN}/view/${it.issueKey}|${it.issueKey}> ${it.summary} [${it.status.name}]`;
+  const issueLine = (it: BacklogIssue): string => {
+    const assignee = it.assignee ? `@${it.assignee.name} ` : '';
+    return `• ${assignee}<https://${SPACE}.${DOMAIN}/view/${it.issueKey}|${it.issueKey}> ${it.summary} [${it.status.name}]`;
+  };
 
   const section = (title: string, arr: BacklogIssue[]): string =>
     arr.length


### PR DESCRIPTION
## 概要
Backlog 期限リマインドの通知挙動と対象担当者を見直しました。これらの変更は `main` にマージされて初めて GitHub Actions の実行に反映されます（Actions は `main` を実行するため）。

## 変更内容
- **該当課題がない場合は Slack へ送信しない**（従来はコメントアウトされており、該当なしでも通知が飛んでいた）
- **「明日」の課題を通知対象から除外**し、対象を「🔴 期限切れ」「🟠 当日」のみに変更（API 取得範囲も当日までに短縮）
- **セクションアイコンを四角 → 丸に変更**（🟥🟧 → 🔴🟠）
- **通知対象をメールアドレス指定の複数担当者に対応**
  - 環境変数 `BACKLOG_ASSIGNEE_EMAILS`（カンマ区切り）で追加指定
  - **APIキー本人は常に対象**に含め、指定メールの担当者を追加（重複IDは除去）
  - 一致するユーザーが見つからないメールがある場合はエラーで停止
  - Slack の各行に担当者名（`@名前`）を表示
- `.gitignore` を追加（`node_modules/`, `dist/` など）
- GitHub Actions ワークフローに `BACKLOG_ASSIGNEE_EMAILS` の env を追加

## 動作に必要な設定
リポジトリの Actions シークレットに **`BACKLOG_ASSIGNEE_EMAILS`** を追加（本人以外の対象者のメールをカンマ区切り）。未設定の場合は本人のみが対象。

## 確認
- `npm run lint`（型チェック）: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yZAWYK6ZqTTqHCH22aDFV

---
_Generated by [Claude Code](https://claude.ai/code/session_012yZAWYK6ZqTTqHCH22aDFV)_