### PR TITLE
指定ドメインのユーザーを通知対象に含める機能を追加

### DIFF
--- a/.github/workflows/reminder.yml
+++ b/.github/workflows/reminder.yml
@@ -35,6 +35,7 @@ jobs:
           BACKLOG_DOMAIN: ${{ secrets.BACKLOG_DOMAIN }} # 例: backlog.jp / backlog.com
           BACKLOG_API_KEY: ${{ secrets.BACKLOG_API_KEY }}
           BACKLOG_ASSIGNEE_EMAILS: ${{ secrets.BACKLOG_ASSIGNEE_EMAILS }} # 通知対象のメールアドレス（カンマ区切り）
+          BACKLOG_ASSIGNEE_DOMAINS: ${{ secrets.BACKLOG_ASSIGNEE_DOMAINS }} # 通知対象に含めるメールドメイン（カンマ区切り）
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
           TIMEZONE: Asia/Tokyo
           SKIP_HOLIDAYS: "true"

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,12 +135,20 @@ const resolveAssigneeIds = async (emailsCsv: string, domainsCsv: string): Promis
   }
 
   const users = await getUsers();
-  const activeUsers = users.filter(u => u.mailAddress);
-  const idByEmail = new Map(
-    activeUsers.map(u => [u.mailAddress.toLowerCase(), u.id] as const)
-  );
+  const usersWithEmail = users.filter(u => u.mailAddress);
 
-  // ② 個別メール指定：一致するユーザーを追加（見つからなければエラー）
+  // 1パスで「メール→ID」の索引作成と、③ドメイン一致ユーザーの追加を同時に行う
+  const domainSet = new Set(domains);
+  const idByEmail = new Map<string, number>();
+  for (const u of usersWithEmail) {
+    const email = u.mailAddress.toLowerCase();
+    idByEmail.set(email, u.id);
+    // ③ ドメイン指定：メールドメインが一致するユーザーを全員追加
+    const domain = email.slice(email.lastIndexOf('@') + 1);
+    if (domain && domainSet.has(domain)) ids.add(u.id);
+  }
+
+  // ② 個別メール指定：一致するユーザーを追加（見つからなければエラー＝設定ミス検知）
   const notFound: string[] = [];
   for (const email of emails) {
     const id = idByEmail.get(email);
@@ -149,15 +157,6 @@ const resolveAssigneeIds = async (emailsCsv: string, domainsCsv: string): Promis
   }
   if (notFound.length > 0) {
     throw new Error(`次のメールアドレスに一致するBacklogユーザーが見つかりません: ${notFound.join(', ')}`);
-  }
-
-  // ③ ドメイン指定：メールドメインが一致するユーザーを全員追加
-  if (domains.length > 0) {
-    const domainSet = new Set(domains);
-    for (const u of activeUsers) {
-      const domain = u.mailAddress.toLowerCase().split('@')[1];
-      if (domain && domainSet.has(domain)) ids.add(u.id);
-    }
   }
 
   return [...ids]; // 本人＋指定担当者（重複除去済み）
@@ -220,16 +219,25 @@ const fetchAllIssues = async (params: Record<string, string | string[]>): Promis
   const since = today.minus({ days: 365 }); // 1年分拾えば十分。必要に応じて短縮可
   const until = today; // 当日まで（明日以降は対象外）
 
-  // 指定担当者（メールアドレスで解決）の課題のみ取得
+  // 指定担当者（メール／ドメインで解決）の課題のみ取得
   const assigneeIds = await resolveAssigneeIds(ASSIGNEE_EMAILS, ASSIGNEE_DOMAINS);
-  const allIssues = await fetchAllIssues({
-    apiKey: API_KEY,
-    'assigneeId[]': assigneeIds.map(String),
-    dueDateSince: iso(since),
-    dueDateUntil: iso(until),
-    sort: 'dueDate',
-    order: 'asc'
-  });
+
+  // 担当者が多いとGETのURLが長くなりHTTP 414等を招くため、assigneeIdを分割取得してマージ
+  const ASSIGNEE_CHUNK = 30;
+  const issuesById = new Map<number, BacklogIssue>();
+  for (let i = 0; i < assigneeIds.length; i += ASSIGNEE_CHUNK) {
+    const chunk = assigneeIds.slice(i, i + ASSIGNEE_CHUNK);
+    const page = await fetchAllIssues({
+      apiKey: API_KEY,
+      'assigneeId[]': chunk.map(String),
+      dueDateSince: iso(since),
+      dueDateUntil: iso(until),
+      sort: 'dueDate',
+      order: 'asc'
+    });
+    for (const it of page) issuesById.set(it.id, it); // issue.id で重複除去
+  }
+  const allIssues = [...issuesById.values()];
 
   // プロジェクトIDを抽出
   const projectIds = [...new Set(allIssues.map(issue => issue.projectId))];

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,8 @@ const TIMEZONE: string = process.env.TIMEZONE || 'Asia/Tokyo';
 const SKIP_HOLIDAYS: boolean = (process.env.SKIP_HOLIDAYS || 'true') === 'true';
 // 通知対象の担当者メールアドレス（カンマ区切りで複数可）。未設定ならAPIキー本人が対象。
 const ASSIGNEE_EMAILS: string = process.env.BACKLOG_ASSIGNEE_EMAILS || '';
+// 通知対象に含めるメールドメイン（カンマ区切りで複数可）。一致するユーザー全員が対象に加わる。
+const ASSIGNEE_DOMAINS: string = process.env.BACKLOG_ASSIGNEE_DOMAINS || '';
 
 // ==== 日付ユーティリティ（JST基準）====
 const today = DateTime.now().setZone(TIMEZONE).startOf('day');
@@ -112,8 +114,8 @@ const getUsers = async (): Promise<BacklogUser[]> => {
   return fetchJson(url);
 };
 
-// APIキー本人は常に対象に含めつつ、メールアドレス（カンマ区切り）で指定された担当者を追加する
-const resolveAssigneeIds = async (emailsCsv: string): Promise<number[]> => {
+// APIキー本人は常に対象に含めつつ、指定メール／指定ドメインの担当者を追加する
+const resolveAssigneeIds = async (emailsCsv: string, domainsCsv: string): Promise<number[]> => {
   // 本人は常に通知対象
   const myself = await getMyself();
   const ids = new Set<number>([myself.id]);
@@ -122,28 +124,40 @@ const resolveAssigneeIds = async (emailsCsv: string): Promise<number[]> => {
     .split(',')
     .map(e => e.trim().toLowerCase())
     .filter(Boolean);
+  const domains = domainsCsv
+    .split(',')
+    .map(d => d.trim().toLowerCase().replace(/^@/, '')) // 先頭の@は許容
+    .filter(Boolean);
 
   // 追加指定がなければ本人のみ
-  if (emails.length === 0) {
+  if (emails.length === 0 && domains.length === 0) {
     return [...ids];
   }
 
   const users = await getUsers();
+  const activeUsers = users.filter(u => u.mailAddress);
   const idByEmail = new Map(
-    users
-      .filter(u => u.mailAddress)
-      .map(u => [u.mailAddress.toLowerCase(), u.id] as const)
+    activeUsers.map(u => [u.mailAddress.toLowerCase(), u.id] as const)
   );
 
+  // ② 個別メール指定：一致するユーザーを追加（見つからなければエラー）
   const notFound: string[] = [];
   for (const email of emails) {
     const id = idByEmail.get(email);
     if (id === undefined) notFound.push(email);
     else ids.add(id);
   }
-
   if (notFound.length > 0) {
     throw new Error(`次のメールアドレスに一致するBacklogユーザーが見つかりません: ${notFound.join(', ')}`);
+  }
+
+  // ③ ドメイン指定：メールドメインが一致するユーザーを全員追加
+  if (domains.length > 0) {
+    const domainSet = new Set(domains);
+    for (const u of activeUsers) {
+      const domain = u.mailAddress.toLowerCase().split('@')[1];
+      if (domain && domainSet.has(domain)) ids.add(u.id);
+    }
   }
 
   return [...ids]; // 本人＋指定担当者（重複除去済み）
@@ -207,7 +221,7 @@ const fetchAllIssues = async (params: Record<string, string | string[]>): Promis
   const until = today; // 当日まで（明日以降は対象外）
 
   // 指定担当者（メールアドレスで解決）の課題のみ取得
-  const assigneeIds = await resolveAssigneeIds(ASSIGNEE_EMAILS);
+  const assigneeIds = await resolveAssigneeIds(ASSIGNEE_EMAILS, ASSIGNEE_DOMAINS);
   const allIssues = await fetchAllIssues({
     apiKey: API_KEY,
     'assigneeId[]': assigneeIds.map(String),


### PR DESCRIPTION
## 概要
メールドメインを指定して、そのドメインの Backlog ユーザー全員を通知対象に含められるようにしました。

## 変更内容
- 環境変数 **`BACKLOG_ASSIGNEE_DOMAINS`**（カンマ区切り、先頭 `@` も許容）を追加
- `resolveAssigneeIds()` が通知対象を以下の合成で決定するように変更（重複IDは除去）
  - ① APIキー本人（常に対象）
  - ② `BACKLOG_ASSIGNEE_EMAILS` の個別指定メール
  - ③ `BACKLOG_ASSIGNEE_DOMAINS` に一致するドメインのユーザー全員
- GitHub Actions ワークフローに `BACKLOG_ASSIGNEE_DOMAINS` の env を追加

## 使い方
Actions シークレット `BACKLOG_ASSIGNEE_DOMAINS` に例えば `gemcook.com` を設定すると、スペース内の `@gemcook.com` ユーザー全員が対象になります。個別メール指定との併用も可能。未設定の場合は従来通り（本人＋個別メール）。

## 注意
ドメイン指定は、スペース内でそのドメインを持つユーザーを一括で対象にします。ただし期限切れ・当日の該当課題が無いユーザーはメッセージに表示されません。

## 確認
- `npm run lint`（型チェック）: パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012yZAWYK6ZqTTqHCH22aDFV

---
_Generated by [Claude Code](https://claude.ai/code/session_012yZAWYK6ZqTTqHCH22aDFV)_